### PR TITLE
npm install を使って textlint の設定を使えるように改修 （要検証）

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,40 +6,38 @@ curriculum-textlintは校正コストを軽減するために[textlint](https://
 textlintのルールに関しては、技術書向けのtextlintルールプリセット[textlint-rule-preset-ja-technical-writing](https://github.com/textlint-ja/textlint-rule-preset-ja-technical-writing)を採用しています。厳しすぎるルールや足りないルールがあればslackやメールでお気軽にご連絡していただけると幸いです。
 
 
-## (注意点)教材はcurriculumディレクトリ内に作成してください
-このリポジトリで設定しているtextlintはcurriculumディレクトリ内のマークダウンファイルを対象としています。
-なので、教材はcurriculumディレクトリ内で作成してください。
-
-
 ## textlintのセットアップ方法
 
-### 1. カリキュラムのルートディレクトリにサブモジュールを追加する
-Gitサブモジュールを追加してください。
+textlint-rule-preset-techpit-curriculum はまだ npm に publish されていないため、Gitリポジトリの指定でインストールが可能です。
+Gitリポジトリは次のとおり： `takayukioda/textlint-rule-preset-techpit-curriculum#master`
 
+```shell
+npm install --save-dev textlint takayukioda/textlint-rule-preset-techpit-curriculum#master
 ```
-$ git submodule add git@github.com:Techpit-Market/curriculum-textlint.git
-```
 
-### 2. ルートディレクトリの package.json に次のスクリプトを追加してください
+### 2. ルートディレクトリの package.json に次の設定を追加してください
 
-package.jsonがルートディレクトリにある場合は以下のコードを追加してください。package.jsonファイルがルートディレクトにない場合は、package.jsonファイルを追加して以下のコードを追記してください。
+package.jsonがルートディレクトリにある場合は以下の設定を追加してください。
 
 ```json
 {
   "scripts": {
-    "postinstall": "npm run update:submodule",
-    "postupdate": "npm run update:submodule",
-    "update:submodule": "git submodule update --init && git submodule foreach git pull origin master && cd curriculum-textlint && npm install",
-    "check": "cd curriculum-textlint && npm run check",
-    "check:fix": "cd curriculum-textlint && npm run check:fix"
+    "check": "textlint ./curriculum/",
+    "check:fix": "textlint --fix ./curriculum/"
   }
 }
+```
+
+package.jsonファイルがルートディレクトにない場合は、次のコマンドを実行してから、上記の設定をpackage.jsonファイルに追記してください。
+
+```shell
+# package.json をテンプレートに沿って生成
+npm init -y
 ```
 
 ### 3. コマンドラインでtextlintを実行する
 
 ```
-npm install
 npm run check
 
 # 機械的に修正可能な箇所を修正する場合は次のコマンドを実行する

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,8 @@
 {
-  "name": "curriculum-textlint",
-  "requires": true,
+  "name": "textlint-rule-preset-techpit-curriculum",
+  "version": "1.0.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@azu/format-text": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,19 +19,47 @@
         "@azu/format-text": "^1.0.1"
       }
     },
+    "@babel/parser": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
+      "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA==",
+      "dev": true
+    },
     "@textlint-rule/textlint-rule-no-invalid-control-character": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@textlint-rule/textlint-rule-no-invalid-control-character/-/textlint-rule-no-invalid-control-character-1.1.1.tgz",
-      "integrity": "sha512-X09pX+werCypFP/D5tq2lF0lld5RBfXPynl2FnIqZ8fLQP35wmzmDemhQTOUa3VQQNIzJb0N3vBs2WjT//Twfw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@textlint-rule/textlint-rule-no-invalid-control-character/-/textlint-rule-no-invalid-control-character-1.2.0.tgz",
+      "integrity": "sha512-FgkOQr14H8D/LQVAEOR2cGWhzItb9MXCAvaBwKkysIfP9Ngwam+8NRmbphQ/GrAm3PXV63QmK1xwAKM1DntwmQ==",
       "dev": true,
       "requires": {
         "execall": "^1.0.0"
       }
     },
+    "@textlint-rule/textlint-rule-no-unmatched-pair": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@textlint-rule/textlint-rule-no-unmatched-pair/-/textlint-rule-no-unmatched-pair-1.0.7.tgz",
+      "integrity": "sha512-ZZxnTWc9/rXfH10KfWZdEpB1rdTdBRUob7694GuKbppUGHgXV90kx5axxWsK78vA0sUeN6HXNy14cPSKqBrSiA==",
+      "dev": true,
+      "requires": {
+        "sentence-splitter": "^3.0.11",
+        "textlint-rule-helper": "2.0.1",
+        "textlint-tester": "5.0.1"
+      },
+      "dependencies": {
+        "textlint-rule-helper": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-2.0.1.tgz",
+          "integrity": "sha512-QNGSOemLVxm1b0qnH5VpRY8uyHgfx/8M+St8wSy/d6mZh0abd+KAvhQSuO8cxmVeRKr/LRkhAB3+0QU5LKhLGw==",
+          "dev": true,
+          "requires": {
+            "unist-util-visit": "^1.1.0"
+          }
+        }
+      }
+    },
     "@textlint/ast-node-types": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.0.3.tgz",
-      "integrity": "sha512-mkkqbuxZkCESmMCrVN5QEgmFqBJAcoAGIaZaQfziqKAyCQBLLgKVJzeFuup9mDm9mvCTKekhLk9yIaEFc8EFxA==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.2.5.tgz",
+      "integrity": "sha512-+rEx4jLOeZpUcdvll7jEg/7hNbwYvHWFy4IGW/tk2JdbyB3SJVyIP6arAwzTH/sp/pO9jftfyZnRj4//sLbLvQ==",
       "dev": true
     },
     "@textlint/ast-tester": {
@@ -176,6 +204,20 @@
       "integrity": "sha512-qQ6dqlg4SYywCywimIbkveQZu1MG6ugf6fcJuWDi3D51FbdkSRsMrPusJ1YoW6Y3XBp0ww9fJjXWtlUStGeQsw==",
       "dev": true
     },
+    "@textlint/regexp-string-matcher": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@textlint/regexp-string-matcher/-/regexp-string-matcher-1.1.0.tgz",
+      "integrity": "sha512-uTPnE1Dw1j+9clXPn61ZUdtg+WyhbgeXHwCTfBev7quHjeCP9PS8NdRkR6wEgmjuLg+xZlI4r/e1r6Bd0xyusQ==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "execall": "^1.0.0",
+        "lodash.sortby": "^4.7.0",
+        "lodash.uniq": "^4.5.0",
+        "lodash.uniqwith": "^4.5.0",
+        "to-regex": "^3.0.2"
+      }
+    },
     "@textlint/text-to-ast": {
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/@textlint/text-to-ast/-/text-to-ast-3.1.7.tgz",
@@ -232,6 +274,18 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@textlint/utils/-/utils-1.0.3.tgz",
       "integrity": "sha512-6oGaBKXYpg5Ooph5p32OFdp1dXDUC1z5mpHg2gmQbx6QZjmP4QX+ygBQdNoCq15d1w88+We6koJl0n0WXjItYw==",
+      "dev": true
+    },
+    "@types/structured-source": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/structured-source/-/structured-source-3.0.0.tgz",
+      "integrity": "sha512-8u+Wo5+GEXe4jZyQ8TplLp+1A7g32ZcVoE7VZu8VcxnlaEm5I/+T579R7q3qKN76jmK0lRshpo4hl4bj/kEPKA==",
+      "dev": true
+    },
+    "@types/unist": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
       "dev": true
     },
     "ajv": {
@@ -305,14 +359,25 @@
       }
     },
     "analyze-desumasu-dearu": {
-      "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/analyze-desumasu-dearu/-/analyze-desumasu-dearu-3.1.0.tgz",
-      "integrity": "sha1-rza5SEVMB4OkMfKrk4pZ8k1A4VA=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/analyze-desumasu-dearu/-/analyze-desumasu-dearu-4.0.0.tgz",
+      "integrity": "sha512-3japlt1pOkEaoH7afOJ7Fw20Ojbaz+5NjPX6tPNx1CjrPPKrq6+U6QYqTijz4TxaW/2uLd7r6Iayod1lIEbSZw==",
       "dev": true,
       "requires": {
         "array-find": "^1.0.0",
-        "kuromojin": "^1.2.1",
-        "object.assign": "^4.0.3"
+        "kuromojin": "^1.4.0",
+        "object.assign": "^4.1.0"
+      },
+      "dependencies": {
+        "kuromojin": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-1.5.1.tgz",
+          "integrity": "sha512-tzt3UUqWqzwHMsahchyrcs9kgbn6OM7xP4QRCd0w5vqE0lA/cjCH0OxjLaekz5cnxGmcy8RfN7La3xOxZOvJ1w==",
+          "dev": true,
+          "requires": {
+            "kuromoji": "0.1.1"
+          }
+        }
       }
     },
     "ansi-regex": {
@@ -343,22 +408,36 @@
       "dev": true
     },
     "array.prototype.find": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
-      "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.1.tgz",
+      "integrity": "sha512-mi+MYNJYLTx2eNYy+Yh6raoQacCsNeeMUaspFPh9Y141lFSsWxxB8V9mM2ye+eqiRs917J6/pJ4M9ZPzenWckA==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.4"
       }
     },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
     "async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.14"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "bail": {
@@ -395,9 +474,15 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
+    "ccount": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.5.tgz",
+      "integrity": "sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw==",
+      "dev": true
+    },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -472,7 +557,7 @@
     },
     "code-point": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/code-point/-/code-point-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/code-point/-/code-point-1.1.0.tgz",
       "integrity": "sha1-mZhB9R9UzK5KDau8hpBjI0YD/s0=",
       "dev": true
     },
@@ -486,6 +571,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
       "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
+      "dev": true
+    },
+    "comma-separated-tokens": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
+      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
       "dev": true
     },
     "commandpost": {
@@ -570,6 +661,16 @@
         "object-keys": "^1.0.12"
       }
     },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      }
+    },
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -604,22 +705,51 @@
       }
     },
     "es-abstract": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.1.1",
+        "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.2.0",
+        "is-regex": "^1.1.0",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+          "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        }
       }
     },
     "es-to-primitive": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
@@ -653,6 +783,16 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      }
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -778,6 +918,37 @@
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
+    "hast-util-from-parse5": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-5.0.3.tgz",
+      "integrity": "sha512-gOc8UB99F6eWVWFtM9jUikjN7QkWxB3nY0df5Z0Zq1/Nkwl5V4hAAsl0tmwlgWl/1shlTF8DnNYLO8X6wRV9pA==",
+      "dev": true,
+      "requires": {
+        "ccount": "^1.0.3",
+        "hastscript": "^5.0.0",
+        "property-information": "^5.0.0",
+        "web-namespaces": "^1.1.2",
+        "xtend": "^4.0.1"
+      }
+    },
+    "hast-util-parse-selector": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.4.tgz",
+      "integrity": "sha512-gW3sxfynIvZApL4L07wryYF4+C9VvH3AUi7LAnVXV4MneGEgwOByXvFo18BgmTWnm7oHAe874jKbIB1YhHSIzA==",
+      "dev": true
+    },
+    "hastscript": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
+      "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
+      "dev": true,
+      "requires": {
+        "comma-separated-tokens": "^1.0.0",
+        "hast-util-parse-selector": "^2.0.0",
+        "property-information": "^5.0.0",
+        "space-separated-tokens": "^1.0.0"
+      }
+    },
     "hosted-git-info": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
@@ -799,6 +970,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
+    },
+    "is-accessor-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^6.0.0"
+      }
     },
     "is-alphabetical": {
       "version": "1.0.4",
@@ -835,10 +1015,19 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
       "dev": true
+    },
+    "is-data-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^6.0.0"
+      }
     },
     "is-date-object": {
       "version": "1.0.1",
@@ -851,6 +1040,26 @@
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
       "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
       "dev": true
+    },
+    "is-descriptor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^1.0.0",
+        "is-data-descriptor": "^1.0.0",
+        "kind-of": "^6.0.2"
+      }
+    },
+    "is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "requires": {
+        "is-plain-object": "^2.0.4"
+      }
     },
     "is-file": {
       "version": "1.0.0",
@@ -878,6 +1087,15 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
     },
     "is-regex": {
       "version": "1.0.4",
@@ -933,6 +1151,12 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
+    },
     "japanese-numerals-to-number": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/japanese-numerals-to-number/-/japanese-numerals-to-number-1.0.2.tgz",
@@ -985,6 +1209,12 @@
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true
+    },
     "kuromoji": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.1.tgz",
@@ -997,9 +1227,9 @@
       }
     },
     "kuromojin": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-1.4.0.tgz",
-      "integrity": "sha512-ZoG3NAW6ATKgo2jBgjVWwE66GeaT2jHgdf0v1dL8+WffuSfvTvX7l6ePgYusSAhHW+dwtneYcbav8N0NhsA0uw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-2.0.0.tgz",
+      "integrity": "sha512-60j/yLkFSc4t4roj8tI8ZNNSiAFnrkgXw8SqXz/9nakfs6mkCvPbrd7S8LDr4YNwEt1IyLys5JQTR9EnYyGHhA==",
       "dev": true,
       "requires": {
         "kuromoji": "0.1.1"
@@ -1017,7 +1247,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -1044,6 +1274,24 @@
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
+    },
+    "lodash.uniqwith": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
+      "integrity": "sha1-egy/ZfQ7WShiWp1NDcVLGMrcfvM=",
+      "dev": true
+    },
     "log-symbols": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
@@ -1066,9 +1314,9 @@
       "dev": true
     },
     "match-index": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/match-index/-/match-index-1.0.1.tgz",
-      "integrity": "sha1-tLZz6ZqzrFpq8wPM9NtwmBK8P1g=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/match-index/-/match-index-1.0.3.tgz",
+      "integrity": "sha512-1XjyBWqCvEFFUDW/MPv0RwbITRD4xQXOvKoPYtLDq8IdZTfdF/cQSo5Yn4qvhfSSZgjgkTFsqJD2wOUG4ovV8Q==",
       "dev": true,
       "requires": {
         "regexp.prototype.flags": "^1.1.1"
@@ -1127,18 +1375,28 @@
       }
     },
     "morpheme-match": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/morpheme-match/-/morpheme-match-1.1.0.tgz",
-      "integrity": "sha1-2PMzC5Xl8n0cthD3Yyhcckwlh0o=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/morpheme-match/-/morpheme-match-2.0.4.tgz",
+      "integrity": "sha512-C3U5g2h47dpztGVePLA8w2O1aQEvuJORwIcahWaCG91YPrq+0u7qcPsF9Nqqe8noFvHwgO7b2EEk3iPnYuGTew==",
       "dev": true
     },
     "morpheme-match-all": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/morpheme-match-all/-/morpheme-match-all-1.1.0.tgz",
-      "integrity": "sha1-l/BTguuJ43VdUIOdd/lZwRHq5D4=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/morpheme-match-all/-/morpheme-match-all-2.0.5.tgz",
+      "integrity": "sha512-a6B6Nh4AhjMoEzVz8NOT5M9f3XwFVPM395gqnFNUXG/KTqQFTb9qM5JJFHJe+SvWfRVXTZSejyXNt+h+jmHUuQ==",
       "dev": true,
       "requires": {
-        "morpheme-match": "^1.1.0"
+        "morpheme-match": "^2.0.4"
+      }
+    },
+    "morpheme-match-textlint": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/morpheme-match-textlint/-/morpheme-match-textlint-2.0.6.tgz",
+      "integrity": "sha512-CX+iQaUjjPMLvas+hZ8zg6Csxx5j1RLaytr+5w6lpBi/oTEV2pv6sgW5Vu3+pNJHbYcaqcuofQZsKocMNUNH8g==",
+      "dev": true,
+      "requires": {
+        "morpheme-match": "^2.0.4",
+        "morpheme-match-all": "^2.0.5"
       }
     },
     "ms": {
@@ -1265,15 +1523,15 @@
       }
     },
     "object.values": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
-      "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
+      "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.6.1",
-        "function-bind": "^1.1.0",
-        "has": "^1.0.1"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
       }
     },
     "once": {
@@ -1346,6 +1604,12 @@
         "error-ex": "^1.2.0"
       }
     },
+    "parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "dev": true
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -1354,7 +1618,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -1383,7 +1647,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
@@ -1414,30 +1678,20 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
-    "prh": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/prh/-/prh-5.4.3.tgz",
-      "integrity": "sha512-W5+gzqOrVLKayPh+2QCur7KYZPsLRfDJd4Tyz5lIXAWwqaX/LQ40FX/P3/Hbfgf7w+EQPdR1yOx6BVf+frG40w==",
-      "dev": true,
-      "requires": {
-        "commandpost": "^1.2.1",
-        "diff": "^3.3.0",
-        "js-yaml": "^3.9.1"
-      },
-      "dependencies": {
-        "diff": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-          "dev": true
-        }
-      }
-    },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
+    },
+    "property-information": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.5.0.tgz",
+      "integrity": "sha512-RgEbCx2HLa1chNgvChcx+rrCWD0ctBmGSE0M7lVm1yyv4UbvbrWoXp/BkVLZefzjrRBGW8/Js6uh/BnlHXFyjA==",
+      "dev": true,
+      "requires": {
+        "xtend": "^4.0.0"
+      }
     },
     "rc-config-loader": {
       "version": "3.0.0",
@@ -1543,6 +1797,16 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
     "regexp.prototype.flags": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
@@ -1557,6 +1821,17 @@
       "resolved": "https://registry.npmjs.org/regx/-/regx-1.0.4.tgz",
       "integrity": "sha1-oO4ywwiRCQIBnKERftQbnd0EGy8=",
       "dev": true
+    },
+    "rehype-parse": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-6.0.2.tgz",
+      "integrity": "sha512-0S3CpvpTAgGmnz8kiCyFLGuW5yA4OQhyNTm/nwPopZ7+PI11WnGl1TTWTGv/2hPEe/g2jRLlhVVSsoDH8waRug==",
+      "dev": true,
+      "requires": {
+        "hast-util-from-parse5": "^5.0.0",
+        "parse5": "^5.0.0",
+        "xtend": "^4.0.0"
+      }
     },
     "remark-frontmatter": {
       "version": "1.3.3",
@@ -1618,6 +1893,12 @@
         "path-parse": "^1.0.6"
       }
     },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
     "rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -1633,6 +1914,15 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -1640,25 +1930,52 @@
       "dev": true
     },
     "sentence-splitter": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-2.3.2.tgz",
-      "integrity": "sha512-QnpHNykm4nI4T6mT+NoVayh9Ixl5DohYCSVqMgPJsO2WejOcqaYTh4HQOkmzaDzXH3NO5pif4z/hpo2NGtgNlg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-3.2.0.tgz",
+      "integrity": "sha512-lKX2tZ1rsA9Tu0gW8vRmMDmIEJoZ1d7cKpzcbFZdUrSpCR6gy/7OPPh7jjT/6Oc6Z79ToUmC2l8tyTEGanVmiA==",
       "dev": true,
       "requires": {
-        "concat-stream": "^1.5.2",
+        "@textlint/ast-node-types": "^4.2.5",
+        "concat-stream": "^2.0.0",
+        "object.values": "^1.1.0",
         "structured-source": "^3.0.2"
+      },
+      "dependencies": {
+        "concat-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+          "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.0.2",
+            "typedarray": "^0.0.6"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
     "sorted-array": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/sorted-array/-/sorted-array-2.0.2.tgz",
-      "integrity": "sha512-5PJPU+PRic0yPU94+YCtokdmasqJ7kLCMg83CIus5yjkeGjYQkxX1X49/71/sgqvtGLpt9Wh+gnKdBOYWzG/9w==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sorted-array/-/sorted-array-2.0.4.tgz",
+      "integrity": "sha512-58INzrX0rL6ttCfsGoFmOuQY5AjR6A5E/MmGKJ5JvWHOey6gOEOC6vO8K6C0Y2bQR6KJ8o8aFwHjp/mJ/HcYsQ==",
       "dev": true
     },
     "sorted-joyo-kanji": {
@@ -1672,6 +1989,12 @@
         "joyo-kanji": "^0.2.1",
         "sorted-array": "^2.0.1"
       }
+    },
+    "space-separated-tokens": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
+      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
+      "dev": true
     },
     "spdx-correct": {
       "version": "3.1.1",
@@ -2008,7 +2331,7 @@
     },
     "table": {
       "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
@@ -2111,46 +2434,26 @@
       }
     },
     "textlint-rule-helper": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-2.0.1.tgz",
-      "integrity": "sha512-QNGSOemLVxm1b0qnH5VpRY8uyHgfx/8M+St8wSy/d6mZh0abd+KAvhQSuO8cxmVeRKr/LRkhAB3+0QU5LKhLGw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-2.1.1.tgz",
+      "integrity": "sha512-6fxgHzoJVkjl3LaC1b2Egi+5wbhG4i0pU0knJmQujVhxIJ3D3AcQQZPs457xKAi5xKz1WayYeTeJ5jrD/hnO7g==",
       "dev": true,
       "requires": {
+        "@textlint/ast-node-types": "^4.2.1",
+        "@textlint/types": "^1.1.2",
+        "structured-source": "^3.0.2",
         "unist-util-visit": "^1.1.0"
       }
     },
     "textlint-rule-ja-no-abusage": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-abusage/-/textlint-rule-ja-no-abusage-1.2.2.tgz",
-      "integrity": "sha512-lDRvfOCh41h0DnenGgfjstBNBh7EZP37r/q/24DP1PKWvVytOtiIxN048KEfm4sXjJZ/eSZOrZrfHqFm1uaiCw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-abusage/-/textlint-rule-ja-no-abusage-2.0.1.tgz",
+      "integrity": "sha512-HUAi0vpjoE+8Jl0OzuhgqYlPzGbHjNr7sQuEFQWmrKUF7LdKTdP0dDcmcJ5rbKKLXZ4eV+6Tf2VfWfQrlIRkGg==",
       "dev": true,
       "requires": {
-        "kuromojin": "^1.3.1",
-        "morpheme-match": "^1.0.1",
-        "textlint-rule-prh": "^3.1.1"
-      },
-      "dependencies": {
-        "prh": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/prh/-/prh-1.1.0.tgz",
-          "integrity": "sha1-HCKyoZmNqqdEWGXlyG+zDluOuzM=",
-          "dev": true,
-          "requires": {
-            "commandpost": "^1.0.1",
-            "js-yaml": "^3.6.1"
-          }
-        },
-        "textlint-rule-prh": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/textlint-rule-prh/-/textlint-rule-prh-3.1.3.tgz",
-          "integrity": "sha1-C9h1N90VyITc/97vCvz5FHyzD8Y=",
-          "dev": true,
-          "requires": {
-            "prh": "^1.0.1",
-            "textlint-rule-helper": "^2.0.0",
-            "untildify": "^3.0.2"
-          }
-        }
+        "kuromojin": "^2.0.0",
+        "morpheme-match-textlint": "^2.0.3",
+        "textlint-rule-prh": "^5.2.1"
       }
     },
     "textlint-rule-ja-no-mixed-period": {
@@ -2164,14 +2467,43 @@
       }
     },
     "textlint-rule-ja-no-redundant-expression": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-redundant-expression/-/textlint-rule-ja-no-redundant-expression-2.0.0.tgz",
-      "integrity": "sha512-QyvZbq7Yujdl3uT7h606i6U6oBROi9A+aWa0DsGWbWpavZWuiK34E5TWUlFaduvscAeq2fejLxruROgdv4WhFw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-redundant-expression/-/textlint-rule-ja-no-redundant-expression-3.0.1.tgz",
+      "integrity": "sha512-Ng1pLiELXqD8RnDbkSaQlQcCQQS6qhFJqbb8HUVs65/wq6Mb4h+gOJOS63yO8e9V7WAYDhjKePTcduu1xwsCfA==",
       "dev": true,
       "requires": {
+        "@textlint/regexp-string-matcher": "^1.0.2",
         "kuromojin": "^1.3.2",
-        "morpheme-match": "^1.0.1",
-        "morpheme-match-all": "^1.1.0"
+        "morpheme-match": "^1.2.1",
+        "morpheme-match-all": "^1.2.0",
+        "textlint-rule-helper": "^2.1.1",
+        "textlint-util-to-string": "^2.1.1"
+      },
+      "dependencies": {
+        "kuromojin": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-1.5.1.tgz",
+          "integrity": "sha512-tzt3UUqWqzwHMsahchyrcs9kgbn6OM7xP4QRCd0w5vqE0lA/cjCH0OxjLaekz5cnxGmcy8RfN7La3xOxZOvJ1w==",
+          "dev": true,
+          "requires": {
+            "kuromoji": "0.1.1"
+          }
+        },
+        "morpheme-match": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/morpheme-match/-/morpheme-match-1.2.1.tgz",
+          "integrity": "sha512-SSIcFPas4Dctx5PbrfKbW5XNADlkcn38LI+fqgB9QtminQ7FXeOR3//rnAmooZ1/5zTGeFoi8H9kFBAH9y1nfQ==",
+          "dev": true
+        },
+        "morpheme-match-all": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/morpheme-match-all/-/morpheme-match-all-1.2.0.tgz",
+          "integrity": "sha512-z8F1k4U8fAMcjkGBDWwVrKZLR8VSvKtYh6+5GZ9hi5mtXrYMILwDMgiPwfNGJvk/liQEG9/oNAJUcwLpyjI9Xg==",
+          "dev": true,
+          "requires": {
+            "morpheme-match": "^1.2.1"
+          }
+        }
       }
     },
     "textlint-rule-ja-no-successive-word": {
@@ -2181,6 +2513,17 @@
       "dev": true,
       "requires": {
         "kuromojin": "^1.3.1"
+      },
+      "dependencies": {
+        "kuromojin": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-1.5.1.tgz",
+          "integrity": "sha512-tzt3UUqWqzwHMsahchyrcs9kgbn6OM7xP4QRCd0w5vqE0lA/cjCH0OxjLaekz5cnxGmcy8RfN7La3xOxZOvJ1w==",
+          "dev": true,
+          "requires": {
+            "kuromoji": "0.1.1"
+          }
+        }
       }
     },
     "textlint-rule-ja-no-weak-phrase": {
@@ -2192,6 +2535,43 @@
         "kuromojin": "^1.3.1",
         "morpheme-match": "^1.0.1",
         "morpheme-match-all": "^1.1.0"
+      },
+      "dependencies": {
+        "kuromojin": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-1.5.1.tgz",
+          "integrity": "sha512-tzt3UUqWqzwHMsahchyrcs9kgbn6OM7xP4QRCd0w5vqE0lA/cjCH0OxjLaekz5cnxGmcy8RfN7La3xOxZOvJ1w==",
+          "dev": true,
+          "requires": {
+            "kuromoji": "0.1.1"
+          }
+        },
+        "morpheme-match": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/morpheme-match/-/morpheme-match-1.2.1.tgz",
+          "integrity": "sha512-SSIcFPas4Dctx5PbrfKbW5XNADlkcn38LI+fqgB9QtminQ7FXeOR3//rnAmooZ1/5zTGeFoi8H9kFBAH9y1nfQ==",
+          "dev": true
+        },
+        "morpheme-match-all": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/morpheme-match-all/-/morpheme-match-all-1.2.0.tgz",
+          "integrity": "sha512-z8F1k4U8fAMcjkGBDWwVrKZLR8VSvKtYh6+5GZ9hi5mtXrYMILwDMgiPwfNGJvk/liQEG9/oNAJUcwLpyjI9Xg==",
+          "dev": true,
+          "requires": {
+            "morpheme-match": "^1.2.1"
+          }
+        }
+      }
+    },
+    "textlint-rule-ja-unnatural-alphabet": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-unnatural-alphabet/-/textlint-rule-ja-unnatural-alphabet-2.0.1.tgz",
+      "integrity": "sha512-n93V8qh6OKdh8OB6yLT+9Xl8DSoZ7gWi51tWdhlLEPIWgBm18nLMgm6Ck+nVc3eENOdRcQURWUpCGotI8wTemA==",
+      "dev": true,
+      "requires": {
+        "@textlint/regexp-string-matcher": "^1.0.2",
+        "match-index": "^1.0.1",
+        "regx": "^1.0.4"
       }
     },
     "textlint-rule-max-comma": {
@@ -2202,6 +2582,18 @@
       "requires": {
         "sentence-splitter": "^2.0.0",
         "unist-util-filter": "^0.2.1"
+      },
+      "dependencies": {
+        "sentence-splitter": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-2.3.2.tgz",
+          "integrity": "sha512-QnpHNykm4nI4T6mT+NoVayh9Ixl5DohYCSVqMgPJsO2WejOcqaYTh4HQOkmzaDzXH3NO5pif4z/hpo2NGtgNlg==",
+          "dev": true,
+          "requires": {
+            "concat-stream": "^1.5.2",
+            "structured-source": "^3.0.2"
+          }
+        }
       }
     },
     "textlint-rule-max-kanji-continuous-len": {
@@ -2224,6 +2616,27 @@
         "sentence-splitter": "^2.0.0",
         "structured-source": "^3.0.2",
         "textlint-rule-helper": "^2.0.0"
+      },
+      "dependencies": {
+        "kuromojin": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-1.5.1.tgz",
+          "integrity": "sha512-tzt3UUqWqzwHMsahchyrcs9kgbn6OM7xP4QRCd0w5vqE0lA/cjCH0OxjLaekz5cnxGmcy8RfN7La3xOxZOvJ1w==",
+          "dev": true,
+          "requires": {
+            "kuromoji": "0.1.1"
+          }
+        },
+        "sentence-splitter": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-2.3.2.tgz",
+          "integrity": "sha512-QnpHNykm4nI4T6mT+NoVayh9Ixl5DohYCSVqMgPJsO2WejOcqaYTh4HQOkmzaDzXH3NO5pif4z/hpo2NGtgNlg==",
+          "dev": true,
+          "requires": {
+            "concat-stream": "^1.5.2",
+            "structured-source": "^3.0.2"
+          }
+        }
       }
     },
     "textlint-rule-no-double-negative-ja": {
@@ -2233,6 +2646,17 @@
       "dev": true,
       "requires": {
         "kuromojin": "^1.1.0"
+      },
+      "dependencies": {
+        "kuromojin": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-1.5.1.tgz",
+          "integrity": "sha512-tzt3UUqWqzwHMsahchyrcs9kgbn6OM7xP4QRCd0w5vqE0lA/cjCH0OxjLaekz5cnxGmcy8RfN7La3xOxZOvJ1w==",
+          "dev": true,
+          "requires": {
+            "kuromoji": "0.1.1"
+          }
+        }
       }
     },
     "textlint-rule-no-doubled-conjunction": {
@@ -2247,21 +2671,50 @@
         "textlint-util-to-string": "^1.2.0"
       },
       "dependencies": {
+        "kuromojin": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-1.5.1.tgz",
+          "integrity": "sha512-tzt3UUqWqzwHMsahchyrcs9kgbn6OM7xP4QRCd0w5vqE0lA/cjCH0OxjLaekz5cnxGmcy8RfN7La3xOxZOvJ1w==",
+          "dev": true,
+          "requires": {
+            "kuromoji": "0.1.1"
+          }
+        },
+        "sentence-splitter": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-2.3.2.tgz",
+          "integrity": "sha512-QnpHNykm4nI4T6mT+NoVayh9Ixl5DohYCSVqMgPJsO2WejOcqaYTh4HQOkmzaDzXH3NO5pif4z/hpo2NGtgNlg==",
+          "dev": true,
+          "requires": {
+            "concat-stream": "^1.5.2",
+            "structured-source": "^3.0.2"
+          }
+        },
         "textlint-rule-helper": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
           "integrity": "sha1-vmjUelFGsW3RFieMmut701YxzNo=",
           "dev": true,
           "requires": {
             "unist-util-visit": "^1.1.0"
           }
+        },
+        "textlint-util-to-string": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/textlint-util-to-string/-/textlint-util-to-string-1.2.1.tgz",
+          "integrity": "sha1-HPiZVtJ1VaVelYjAazWlDw0dRvk=",
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.0.1",
+            "structured-source": "^3.0.2"
+          }
         }
       }
     },
     "textlint-rule-no-doubled-conjunctive-particle-ga": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-conjunctive-particle-ga/-/textlint-rule-no-doubled-conjunctive-particle-ga-1.0.2.tgz",
-      "integrity": "sha1-uctnlVWuoqsNT/z6TdL/q3G/AFc=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-conjunctive-particle-ga/-/textlint-rule-no-doubled-conjunctive-particle-ga-1.1.0.tgz",
+      "integrity": "sha512-5uTZEw0S1j27DJ2vxdSqmqekZGuzOz2c8axtjJR1XiLc/miB8f7Rz3S16Mq+M2W06wcJTdoM87ix5XWa+4oe8A==",
       "dev": true,
       "requires": {
         "kuromojin": "^1.1.0",
@@ -2270,9 +2723,18 @@
         "textlint-util-to-string": "^1.2.0"
       },
       "dependencies": {
+        "kuromojin": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-1.5.1.tgz",
+          "integrity": "sha512-tzt3UUqWqzwHMsahchyrcs9kgbn6OM7xP4QRCd0w5vqE0lA/cjCH0OxjLaekz5cnxGmcy8RfN7La3xOxZOvJ1w==",
+          "dev": true,
+          "requires": {
+            "kuromoji": "0.1.1"
+          }
+        },
         "sentence-splitter": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/sentence-splitter/-/sentence-splitter-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-1.2.0.tgz",
           "integrity": "sha1-wcOEFM8UXscX/UN8rCDJiOD9DUY=",
           "dev": true,
           "requires": {
@@ -2281,34 +2743,105 @@
         },
         "textlint-rule-helper": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
           "integrity": "sha1-vmjUelFGsW3RFieMmut701YxzNo=",
           "dev": true,
           "requires": {
             "unist-util-visit": "^1.1.0"
           }
+        },
+        "textlint-util-to-string": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/textlint-util-to-string/-/textlint-util-to-string-1.2.1.tgz",
+          "integrity": "sha1-HPiZVtJ1VaVelYjAazWlDw0dRvk=",
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.0.1",
+            "structured-source": "^3.0.2"
+          }
         }
       }
     },
     "textlint-rule-no-doubled-joshi": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-joshi/-/textlint-rule-no-doubled-joshi-3.5.1.tgz",
-      "integrity": "sha1-dZxsXe+AdfhJ2aTfVRwtKggVui8=",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-joshi/-/textlint-rule-no-doubled-joshi-3.7.2.tgz",
+      "integrity": "sha512-6du7XciMGZuvAdEL0vAA7JSXVS9NbtWwsbVCeJ8ynSl4hNI+g9tGeN6zYZARJD6/cyklP+zFSvXixKf6nFFqMA==",
       "dev": true,
       "requires": {
-        "kuromojin": "^1.2.1",
-        "sentence-splitter": "^2.2.0",
-        "textlint-rule-helper": "^1.1.4",
-        "textlint-util-to-string": "^1.1.0"
+        "kuromojin": "^2.0.0",
+        "sentence-splitter": "^3.2.0",
+        "textlint-rule-helper": "^2.1.1",
+        "textlint-util-to-string": "^3.0.0"
       },
       "dependencies": {
-        "textlint-rule-helper": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
-          "integrity": "sha1-vmjUelFGsW3RFieMmut701YxzNo=",
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
+        },
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+          "dev": true
+        },
+        "textlint-util-to-string": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/textlint-util-to-string/-/textlint-util-to-string-3.0.0.tgz",
+          "integrity": "sha512-NLvumkbmdynXZIYdv9JR2amjsT8ZiPPmr/6vFLcJU2NmZTtZoE8DfEOW9BtD/pbUAQaukwGjbEFc93lBIL1o/w==",
           "dev": true,
           "requires": {
-            "unist-util-visit": "^1.1.0"
+            "@textlint/ast-node-types": "^4.2.4",
+            "@types/structured-source": "^3.0.0",
+            "rehype-parse": "^6.0.1",
+            "structured-source": "^3.0.2",
+            "unified": "^8.4.0"
+          }
+        },
+        "unified": {
+          "version": "8.4.2",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
+          "integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+          "dev": true,
+          "requires": {
+            "bail": "^1.0.0",
+            "extend": "^3.0.0",
+            "is-plain-obj": "^2.0.0",
+            "trough": "^1.0.0",
+            "vfile": "^4.0.0"
+          }
+        },
+        "unist-util-stringify-position": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+          "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.2"
+          }
+        },
+        "vfile": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.1.1.tgz",
+          "integrity": "sha512-lRjkpyDGjVlBA7cDQhQ+gNcvB1BGaTHYuSOcY3S7OhDmBtnzX95FhtZZDecSTDm6aajFymyve6S5DN4ZHGezdQ==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "is-buffer": "^2.0.0",
+            "replace-ext": "1.0.0",
+            "unist-util-stringify-position": "^2.0.0",
+            "vfile-message": "^2.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
+          "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-stringify-position": "^2.0.0"
           }
         }
       }
@@ -2323,9 +2856,18 @@
         "textlint-rule-helper": "^1.1.4"
       },
       "dependencies": {
+        "kuromojin": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-1.5.1.tgz",
+          "integrity": "sha512-tzt3UUqWqzwHMsahchyrcs9kgbn6OM7xP4QRCd0w5vqE0lA/cjCH0OxjLaekz5cnxGmcy8RfN7La3xOxZOvJ1w==",
+          "dev": true,
+          "requires": {
+            "kuromoji": "0.1.1"
+          }
+        },
         "textlint-rule-helper": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
           "integrity": "sha1-vmjUelFGsW3RFieMmut701YxzNo=",
           "dev": true,
           "requires": {
@@ -2346,7 +2888,7 @@
       "dependencies": {
         "textlint-rule-helper": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
           "integrity": "sha1-vmjUelFGsW3RFieMmut701YxzNo=",
           "dev": true,
           "requires": {
@@ -2367,7 +2909,7 @@
       "dependencies": {
         "textlint-rule-helper": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
           "integrity": "sha1-vmjUelFGsW3RFieMmut701YxzNo=",
           "dev": true,
           "requires": {
@@ -2377,161 +2919,217 @@
       }
     },
     "textlint-rule-no-mix-dearu-desumasu": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-mix-dearu-desumasu/-/textlint-rule-no-mix-dearu-desumasu-3.0.3.tgz",
-      "integrity": "sha1-rEuBYLT0ZkSkpA1i/gHY23Zwt8M=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-mix-dearu-desumasu/-/textlint-rule-no-mix-dearu-desumasu-4.0.1.tgz",
+      "integrity": "sha512-brkZc+l3Y34C31zHXyMUITbdsHj0i1MeZ7IQfhR38nvXzHlKWWFqoesXndLSml6yiVIJn4glJhiiJ1yErm86Sw==",
       "dev": true,
       "requires": {
-        "analyze-desumasu-dearu": "^3.1.0",
+        "analyze-desumasu-dearu": "^4.0.0",
         "textlint-rule-helper": "^2.0.0",
-        "unist-util-visit": "^1.1.0"
-      }
-    },
-    "textlint-rule-no-nfd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-nfd/-/textlint-rule-no-nfd-1.0.1.tgz",
-      "integrity": "sha1-v0g/hE5kHvI64/gjYUIanlO11lo=",
-      "dev": true,
-      "requires": {
-        "match-index": "^1.0.1",
-        "textlint-rule-helper": "^1.1.5",
-        "unorm": "^1.4.1"
+        "unist-util-visit": "^2.0.2"
       },
       "dependencies": {
-        "textlint-rule-helper": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
-          "integrity": "sha1-vmjUelFGsW3RFieMmut701YxzNo=",
+        "unist-util-is": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.2.tgz",
+          "integrity": "sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ==",
+          "dev": true
+        },
+        "unist-util-visit": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.2.tgz",
+          "integrity": "sha512-HoHNhGnKj6y+Sq+7ASo2zpVdfdRifhTgX2KTU3B/sO/TTlZchp7E3S4vjRzDJ7L60KmrCPsQkVK3lEF3cz36XQ==",
           "dev": true,
           "requires": {
-            "unist-util-visit": "^1.1.0"
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^4.0.0",
+            "unist-util-visit-parents": "^3.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.0.2.tgz",
+          "integrity": "sha512-yJEfuZtzFpQmg1OSCyS9M5NJRrln/9FbYosH3iW0MG402QbdbaB8ZESwUv9RO6nRfLAKvWcMxCwdLWOov36x/g==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^4.0.0"
           }
         }
       }
     },
-    "textlint-rule-preset-ja-technical-writing": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-preset-ja-technical-writing/-/textlint-rule-preset-ja-technical-writing-3.1.0.tgz",
-      "integrity": "sha512-/AUFc+2N9R4QZUzOI1IPjQLENMI6f4uIDE7pgZKpFBglworlVFvLTIvZdbefGnl0vxP5BYp+zK0/5Rf4+h8W0g==",
+    "textlint-rule-no-nfd": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-nfd/-/textlint-rule-no-nfd-1.0.2.tgz",
+      "integrity": "sha512-n6tUx40/V6koDo78qqePHxSovuwSIKO0xwY3FCqVDbcfg9GxQCjde1twQJ99T3bs4LabhPOo/Pt3USaQ9XcTRQ==",
       "dev": true,
       "requires": {
-        "@textlint-rule/textlint-rule-no-invalid-control-character": "^1.1.0",
-        "textlint-rule-ja-no-abusage": "^1.1.1",
-        "textlint-rule-ja-no-mixed-period": "^2.0.0",
-        "textlint-rule-ja-no-redundant-expression": "^2.0.0",
+        "match-index": "^1.0.3",
+        "textlint-rule-helper": "^2.1.1",
+        "unorm": "^1.4.1"
+      }
+    },
+    "textlint-rule-preset-ja-technical-writing": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-preset-ja-technical-writing/-/textlint-rule-preset-ja-technical-writing-4.0.0.tgz",
+      "integrity": "sha512-Ji7QSPSsmkmrKWtWPEUlC/sGQD90ATQX4M6/DTWuErBveYD0OOA3f3VMvA5M56QDO7zXRkWKkcpFvfLt/P3LFA==",
+      "dev": true,
+      "requires": {
+        "@textlint-rule/textlint-rule-no-invalid-control-character": "^1.2.0",
+        "@textlint-rule/textlint-rule-no-unmatched-pair": "^1.0.7",
+        "@textlint/module-interop": "^1.0.2",
+        "textlint-rule-ja-no-abusage": "^2.0.1",
+        "textlint-rule-ja-no-mixed-period": "^2.1.1",
+        "textlint-rule-ja-no-redundant-expression": "^3.0.1",
         "textlint-rule-ja-no-successive-word": "^1.1.0",
-        "textlint-rule-ja-no-weak-phrase": "^1.0.2",
-        "textlint-rule-max-comma": "^1.0.2",
-        "textlint-rule-max-kanji-continuous-len": "^1.1.0",
-        "textlint-rule-max-ten": "^2.0.1",
-        "textlint-rule-no-double-negative-ja": "^1.0.4",
+        "textlint-rule-ja-no-weak-phrase": "^1.0.4",
+        "textlint-rule-ja-unnatural-alphabet": "2.0.1",
+        "textlint-rule-max-comma": "^1.0.4",
+        "textlint-rule-max-kanji-continuous-len": "^1.1.1",
+        "textlint-rule-max-ten": "^2.0.3",
+        "textlint-rule-no-double-negative-ja": "^1.0.5",
         "textlint-rule-no-doubled-conjunction": "^1.0.2",
-        "textlint-rule-no-doubled-conjunctive-particle-ga": "^1.0.2",
-        "textlint-rule-no-doubled-joshi": "^3.3.0",
-        "textlint-rule-no-dropping-the-ra": "^1.0.3",
+        "textlint-rule-no-doubled-conjunctive-particle-ga": "^1.1.0",
+        "textlint-rule-no-doubled-joshi": "^3.5.2",
+        "textlint-rule-no-dropping-the-ra": "^1.1.2",
         "textlint-rule-no-exclamation-question-mark": "^1.0.2",
-        "textlint-rule-no-hankaku-kana": "^1.0.1",
-        "textlint-rule-no-mix-dearu-desumasu": "^3.0.2",
+        "textlint-rule-no-hankaku-kana": "^1.0.2",
+        "textlint-rule-no-mix-dearu-desumasu": "^4.0.0",
         "textlint-rule-no-nfd": "^1.0.1",
-        "textlint-rule-preset-jtf-style": "^2.3.1",
-        "textlint-rule-sentence-length": "^2.1.1"
+        "textlint-rule-preset-jtf-style": "^2.3.3",
+        "textlint-rule-sentence-length": "^2.1.2"
       }
     },
     "textlint-rule-preset-jtf-style": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/textlint-rule-preset-jtf-style/-/textlint-rule-preset-jtf-style-2.3.1.tgz",
-      "integrity": "sha512-x/2sGx7NpMnMv9OfJH8wm/AILw//fgWRTZoNlTrGhKpNs+k5L0mnRbBZLTHlxXRfSSi3SbSkmSAvVI+8IQKF0Q==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/textlint-rule-preset-jtf-style/-/textlint-rule-preset-jtf-style-2.3.4.tgz",
+      "integrity": "sha512-9z1b4/Y3Q0q+a1JrFj5fheO1DNyBaFysJg4YLwBPJ8YB3gtwwxpHhx141zyJXfnzzTZDVCaIqnM6cPHijcyRuw==",
       "dev": true,
       "requires": {
         "analyze-desumasu-dearu": "^2.1.2",
         "japanese-numerals-to-number": "^1.0.2",
-        "match-index": "^1.0.1",
+        "match-index": "^1.0.3",
         "moji": "^0.5.1",
         "regexp.prototype.flags": "^1.1.1",
         "regx": "^1.0.4",
         "sorted-joyo-kanji": "^0.2.0",
         "textlint-rule-helper": "^2.0.0",
-        "textlint-rule-prh": "^5.0.0"
+        "textlint-rule-prh": "^5.2.1"
       },
       "dependencies": {
         "analyze-desumasu-dearu": {
           "version": "2.1.5",
-          "resolved": "http://registry.npmjs.org/analyze-desumasu-dearu/-/analyze-desumasu-dearu-2.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/analyze-desumasu-dearu/-/analyze-desumasu-dearu-2.1.5.tgz",
           "integrity": "sha1-nKoqWgYUbCBnn33J869Sfbb2j0E=",
           "dev": true
-        },
-        "diff": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-          "dev": true
-        },
-        "prh": {
-          "version": "5.4.3",
-          "resolved": "https://registry.npmjs.org/prh/-/prh-5.4.3.tgz",
-          "integrity": "sha512-W5+gzqOrVLKayPh+2QCur7KYZPsLRfDJd4Tyz5lIXAWwqaX/LQ40FX/P3/Hbfgf7w+EQPdR1yOx6BVf+frG40w==",
-          "dev": true,
-          "requires": {
-            "commandpost": "^1.2.1",
-            "diff": "^3.3.0",
-            "js-yaml": "^3.9.1"
-          }
-        },
-        "textlint-rule-prh": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/textlint-rule-prh/-/textlint-rule-prh-5.2.0.tgz",
-          "integrity": "sha512-ZPTt09YoQ6r0xvDLXs0A9y96GPIFrwr9kC1hlZ6utMarJYr/7Si166hP8oumadfj2u7l+lgKjxfe8vn2/aVhcQ==",
-          "dev": true,
-          "requires": {
-            "prh": "^5.4.3",
-            "textlint-rule-helper": "^2.0.0",
-            "untildify": "^3.0.2"
-          }
         }
       }
     },
     "textlint-rule-prh": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-prh/-/textlint-rule-prh-5.2.0.tgz",
-      "integrity": "sha512-ZPTt09YoQ6r0xvDLXs0A9y96GPIFrwr9kC1hlZ6utMarJYr/7Si166hP8oumadfj2u7l+lgKjxfe8vn2/aVhcQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-prh/-/textlint-rule-prh-5.3.0.tgz",
+      "integrity": "sha512-gdod+lL1SWUDyXs1ICEwvQawaSshT3mvPGufBIjF2R5WFPdKQDMsiuzsjkLm+aF+9d97dA6pFsiyC8gSW7mSgg==",
       "dev": true,
       "requires": {
-        "prh": "^5.4.3",
-        "textlint-rule-helper": "^2.0.0",
-        "untildify": "^3.0.2"
+        "@babel/parser": "^7.7.5",
+        "prh": "^5.4.4",
+        "textlint-rule-helper": "^2.1.1",
+        "untildify": "^3.0.3"
+      },
+      "dependencies": {
+        "prh": {
+          "version": "5.4.4",
+          "resolved": "https://registry.npmjs.org/prh/-/prh-5.4.4.tgz",
+          "integrity": "sha512-UATF+R/2H8owxwPvF12Knihu9aYGTuZttGHrEEq5NBWz38mREh23+WvCVKX3fhnIZIMV7ye6E1fnqAl+V6WYEw==",
+          "dev": true,
+          "requires": {
+            "commandpost": "^1.2.1",
+            "diff": "^4.0.1",
+            "js-yaml": "^3.9.1"
+          }
+        }
       }
     },
     "textlint-rule-sentence-length": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/textlint-rule-sentence-length/-/textlint-rule-sentence-length-2.1.1.tgz",
-      "integrity": "sha512-5LIsGd2Og4KQhDN99hwkW0iPDk4lPAgvkbi9EtlQ5rdHPhjuoj+nbpM0BXKR5boF1p/9O2UEnA3aUBp0az81Ng==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-sentence-length/-/textlint-rule-sentence-length-2.2.0.tgz",
+      "integrity": "sha512-0C7XZvqcdDwBQC1Sfyr47uDAChH0dO3O4gjxG4C/cwRFK8cyjIic8h7g+xaN7c9x+4OoMz+89SksuaHLo5UvqQ==",
       "dev": true,
       "requires": {
-        "sentence-splitter": "^3.0.10",
-        "textlint-rule-helper": "^2.0.0",
-        "textlint-util-to-string": "^2.1.1"
+        "@textlint/regexp-string-matcher": "^1.1.0",
+        "sentence-splitter": "^3.0.11",
+        "textlint-rule-helper": "^2.1.1",
+        "textlint-util-to-string": "^3.0.0"
       },
       "dependencies": {
-        "sentence-splitter": {
-          "version": "3.0.11",
-          "resolved": "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-3.0.11.tgz",
-          "integrity": "sha512-8k/74ErjpdvgBVLQ7kI7jbbaqNdgMXVqMF8gWlJan25xfm1mg8cYmHQgMb+zx8xyocm1Dq46af4TpmnKWHr/yA==",
-          "dev": true,
-          "requires": {
-            "@textlint/ast-node-types": "^4.0.2",
-            "concat-stream": "^1.5.2",
-            "object.values": "^1.0.4",
-            "structured-source": "^3.0.2"
-          }
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
+        },
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+          "dev": true
         },
         "textlint-util-to-string": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/textlint-util-to-string/-/textlint-util-to-string-2.1.1.tgz",
-          "integrity": "sha512-PW6rXqLNGL3xZ6d5/INrX+pt8qbffmeDPLcvkBOlfNpDRFhVvNNjFmZXH86ZQjrOz9t/nNZDBXqnzqJuioJbSQ==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/textlint-util-to-string/-/textlint-util-to-string-3.0.0.tgz",
+          "integrity": "sha512-NLvumkbmdynXZIYdv9JR2amjsT8ZiPPmr/6vFLcJU2NmZTtZoE8DfEOW9BtD/pbUAQaukwGjbEFc93lBIL1o/w==",
           "dev": true,
           "requires": {
-            "object-assign": "^4.0.1",
-            "structured-source": "^3.0.2"
+            "@textlint/ast-node-types": "^4.2.4",
+            "@types/structured-source": "^3.0.0",
+            "rehype-parse": "^6.0.1",
+            "structured-source": "^3.0.2",
+            "unified": "^8.4.0"
+          }
+        },
+        "unified": {
+          "version": "8.4.2",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
+          "integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+          "dev": true,
+          "requires": {
+            "bail": "^1.0.0",
+            "extend": "^3.0.0",
+            "is-plain-obj": "^2.0.0",
+            "trough": "^1.0.0",
+            "vfile": "^4.0.0"
+          }
+        },
+        "unist-util-stringify-position": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+          "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.2"
+          }
+        },
+        "vfile": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.1.1.tgz",
+          "integrity": "sha512-lRjkpyDGjVlBA7cDQhQ+gNcvB1BGaTHYuSOcY3S7OhDmBtnzX95FhtZZDecSTDm6aajFymyve6S5DN4ZHGezdQ==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "is-buffer": "^2.0.0",
+            "replace-ext": "1.0.0",
+            "unist-util-stringify-position": "^2.0.0",
+            "vfile-message": "^2.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
+          "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-stringify-position": "^2.0.0"
           }
         }
       }
@@ -2557,14 +3155,37 @@
         }
       }
     },
+    "textlint-tester": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/textlint-tester/-/textlint-tester-5.0.1.tgz",
+      "integrity": "sha512-MKN38gIQ9/Q3nKg1cnKUVl81bjsfoqy6yq7qptvf3733Ng22K2KoMmTyk8s8C/y7SGx8pN+idsO86DCGEB8q7w==",
+      "dev": true,
+      "requires": {
+        "@textlint/feature-flag": "^3.0.5",
+        "@textlint/kernel": "^3.0.0",
+        "textlint": "^11.0.1"
+      }
+    },
     "textlint-util-to-string": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/textlint-util-to-string/-/textlint-util-to-string-1.2.1.tgz",
-      "integrity": "sha1-HPiZVtJ1VaVelYjAazWlDw0dRvk=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/textlint-util-to-string/-/textlint-util-to-string-2.1.1.tgz",
+      "integrity": "sha512-PW6rXqLNGL3xZ6d5/INrX+pt8qbffmeDPLcvkBOlfNpDRFhVvNNjFmZXH86ZQjrOz9t/nNZDBXqnzqJuioJbSQ==",
       "dev": true,
       "requires": {
         "object-assign": "^4.0.1",
         "structured-source": "^3.0.2"
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "traverse": {
@@ -2700,9 +3321,9 @@
       }
     },
     "unorm": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.4.1.tgz",
-      "integrity": "sha1-NkIA1fE2RsqLzURJAnEzVhR5IwA=",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
+      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
       "dev": true
     },
     "untildify": {
@@ -2753,6 +3374,12 @@
       "requires": {
         "unist-util-stringify-position": "^1.1.1"
       }
+    },
+    "web-namespaces": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
+      "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==",
+      "dev": true
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -557,7 +557,7 @@
     },
     "code-point": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point/-/code-point-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/code-point/-/code-point-1.1.0.tgz",
       "integrity": "sha1-mZhB9R9UzK5KDau8hpBjI0YD/s0=",
       "dev": true
     },
@@ -2692,7 +2692,7 @@
         },
         "textlint-rule-helper": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
           "integrity": "sha1-vmjUelFGsW3RFieMmut701YxzNo=",
           "dev": true,
           "requires": {
@@ -2734,7 +2734,7 @@
         },
         "sentence-splitter": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/sentence-splitter/-/sentence-splitter-1.2.0.tgz",
           "integrity": "sha1-wcOEFM8UXscX/UN8rCDJiOD9DUY=",
           "dev": true,
           "requires": {
@@ -2743,7 +2743,7 @@
         },
         "textlint-rule-helper": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
           "integrity": "sha1-vmjUelFGsW3RFieMmut701YxzNo=",
           "dev": true,
           "requires": {
@@ -2867,7 +2867,7 @@
         },
         "textlint-rule-helper": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
           "integrity": "sha1-vmjUelFGsW3RFieMmut701YxzNo=",
           "dev": true,
           "requires": {
@@ -2888,7 +2888,7 @@
       "dependencies": {
         "textlint-rule-helper": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
           "integrity": "sha1-vmjUelFGsW3RFieMmut701YxzNo=",
           "dev": true,
           "requires": {
@@ -2909,7 +2909,7 @@
       "dependencies": {
         "textlint-rule-helper": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
           "integrity": "sha1-vmjUelFGsW3RFieMmut701YxzNo=",
           "dev": true,
           "requires": {
@@ -3019,7 +3019,7 @@
       "dependencies": {
         "analyze-desumasu-dearu": {
           "version": "2.1.5",
-          "resolved": "https://registry.npmjs.org/analyze-desumasu-dearu/-/analyze-desumasu-dearu-2.1.5.tgz",
+          "resolved": "http://registry.npmjs.org/analyze-desumasu-dearu/-/analyze-desumasu-dearu-2.1.5.tgz",
           "integrity": "sha1-nKoqWgYUbCBnn33J869Sfbb2j0E=",
           "dev": true
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,76 +34,113 @@
       "integrity": "sha512-mkkqbuxZkCESmMCrVN5QEgmFqBJAcoAGIaZaQfziqKAyCQBLLgKVJzeFuup9mDm9mvCTKekhLk9yIaEFc8EFxA==",
       "dev": true
     },
-    "@textlint/ast-traverse": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-traverse/-/ast-traverse-2.0.9.tgz",
-      "integrity": "sha512-E2neVj65wyadt3hr9R+DHW01dG4dNOMmFRab7Bph/rkDDeK85w/6RNJgIt9vBCPtt7a4bndTj1oZrK6wDZAEtQ==",
+    "@textlint/ast-tester": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-tester/-/ast-tester-2.1.6.tgz",
+      "integrity": "sha512-i+UrSKZXs561g8LXsCBkgpNYkgBS3T3Pif2/+DraZmSKpQ2r2D1yCOdH82IGPWWpQ/GMSg6Z0qpLJpjnYz+bpg==",
       "dev": true,
       "requires": {
-        "@textlint/ast-node-types": "^4.0.3"
+        "@textlint/ast-node-types": "^4.2.5"
+      },
+      "dependencies": {
+        "@textlint/ast-node-types": {
+          "version": "4.2.5",
+          "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.2.5.tgz",
+          "integrity": "sha512-+rEx4jLOeZpUcdvll7jEg/7hNbwYvHWFy4IGW/tk2JdbyB3SJVyIP6arAwzTH/sp/pO9jftfyZnRj4//sLbLvQ==",
+          "dev": true
+        }
+      }
+    },
+    "@textlint/ast-traverse": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-traverse/-/ast-traverse-2.1.7.tgz",
+      "integrity": "sha512-73Nw0R4TaskPmF36Hop1DZ8AbH339WrGiLQjzbOLaXHaBHQ4hdNw28UMlw4glfPZb7/zvxPcJRtg9AB8F3ZW0g==",
+      "dev": true,
+      "requires": {
+        "@textlint/ast-node-types": "^4.2.5"
+      },
+      "dependencies": {
+        "@textlint/ast-node-types": {
+          "version": "4.2.5",
+          "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.2.5.tgz",
+          "integrity": "sha512-+rEx4jLOeZpUcdvll7jEg/7hNbwYvHWFy4IGW/tk2JdbyB3SJVyIP6arAwzTH/sp/pO9jftfyZnRj4//sLbLvQ==",
+          "dev": true
+        }
       }
     },
     "@textlint/feature-flag": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@textlint/feature-flag/-/feature-flag-3.0.5.tgz",
-      "integrity": "sha512-hXTDGvltgiUtJs7QhALSILNE+g0cdY4CyqHR2r5+EmiYbS3NuqWVLn3GZYUPWXl9rVDky/IpR+6DF0uLJF8m8Q==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@textlint/feature-flag/-/feature-flag-3.1.6.tgz",
+      "integrity": "sha512-R2s027/WG3zhCMHZG79OhRFmkSL2ghwvFYg/W+2VUva5aYC8i9yeuwRyWt7m83tP1qlI+bq7j3S04fyn6yNheg==",
       "dev": true,
       "requires": {
         "map-like": "^2.0.0"
       }
     },
     "@textlint/fixer-formatter": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@textlint/fixer-formatter/-/fixer-formatter-3.0.8.tgz",
-      "integrity": "sha512-LTHcCLTyESdz90NGYzrYC0juSqLzGBc5VMMRO8Xvz3fapBya/Sn5ncgvsHqnKY0OIbV/IdOT54G2F46D8R6P9Q==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@textlint/fixer-formatter/-/fixer-formatter-3.1.13.tgz",
+      "integrity": "sha512-FXqAJZ+5fLsOZjvFmn1JhCer8gQI4ZQk3R45bXizRJm6DASByPAGGh/MAQxxHSGeR5wR8miO/koxA2BrS8OhAw==",
       "dev": true,
       "requires": {
-        "@textlint/kernel": "^3.0.0",
+        "@textlint/module-interop": "^1.0.2",
+        "@textlint/types": "^1.3.1",
         "chalk": "^1.1.3",
-        "debug": "^2.1.0",
-        "diff": "^2.2.2",
-        "interop-require": "^1.0.0",
+        "debug": "^4.1.1",
+        "diff": "^4.0.1",
         "is-file": "^1.0.0",
         "string-width": "^1.0.1",
+        "strip-ansi": "^6.0.0",
         "text-table": "^0.2.0",
         "try-resolve": "^1.0.1"
       }
     },
     "@textlint/kernel": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@textlint/kernel/-/kernel-3.0.0.tgz",
-      "integrity": "sha512-SxHWr6VAD/SdqTCy1uB03bFLbGYbhZeQTeUuIJE6s1pD7wtQ1+Y1n8nx9I9m7nqGZi5eYuVA6WnpvCq10USz+w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/kernel/-/kernel-3.2.1.tgz",
+      "integrity": "sha512-gMCgP/tAjCX8dGqgu7nhUwaDC/TzDKeRZb9qa50nqbnILRasKplj3lOWn2osZdkScVZPLQp+al1pDh9pU4D+Dw==",
       "dev": true,
       "requires": {
-        "@textlint/ast-node-types": "^4.0.3",
-        "@textlint/ast-traverse": "^2.0.9",
-        "@textlint/feature-flag": "^3.0.5",
-        "@types/bluebird": "^3.5.18",
-        "bluebird": "^3.5.1",
-        "debug": "^2.6.6",
-        "deep-equal": "^1.0.1",
+        "@textlint/ast-node-types": "^4.2.5",
+        "@textlint/ast-tester": "^2.1.6",
+        "@textlint/ast-traverse": "^2.1.7",
+        "@textlint/feature-flag": "^3.1.6",
+        "@textlint/types": "^1.3.1",
+        "@textlint/utils": "^1.0.3",
+        "debug": "^4.1.1",
+        "deep-equal": "^1.1.0",
         "map-like": "^2.0.0",
-        "object-assign": "^4.1.1",
         "structured-source": "^3.0.2"
+      },
+      "dependencies": {
+        "@textlint/ast-node-types": {
+          "version": "4.2.5",
+          "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.2.5.tgz",
+          "integrity": "sha512-+rEx4jLOeZpUcdvll7jEg/7hNbwYvHWFy4IGW/tk2JdbyB3SJVyIP6arAwzTH/sp/pO9jftfyZnRj4//sLbLvQ==",
+          "dev": true
+        }
       }
     },
     "@textlint/linter-formatter": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-3.0.8.tgz",
-      "integrity": "sha512-hayZi4ybj01Km9Soi34cT8EkmEcqGgQKHu1tvPQVd8S2zaE3m/8nmf6qhwAo/HAwMzbIj0XxdV8nVuiUfz8ADQ==",
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-3.1.12.tgz",
+      "integrity": "sha512-OEP4pklu01MEgBJrftD9vwe3HFx+jhiEe1JFIgf7GZ4a0fSer5vQWXBo5wHW6WtZtSa+iLBsLC3mI5VMeshzdA==",
       "dev": true,
       "requires": {
         "@azu/format-text": "^1.0.1",
         "@azu/style-format": "^1.0.0",
-        "@textlint/kernel": "^3.0.0",
+        "@textlint/module-interop": "^1.0.2",
+        "@textlint/types": "^1.3.1",
         "chalk": "^1.0.0",
         "concat-stream": "^1.5.1",
+        "debug": "^4.1.1",
+        "is-file": "^1.0.0",
         "js-yaml": "^3.2.4",
         "optionator": "^0.8.1",
         "pluralize": "^2.0.0",
         "string-width": "^1.0.1",
         "string.prototype.padstart": "^3.0.0",
-        "strip-ansi": "^3.0.1",
+        "strip-ansi": "^6.0.0",
         "table": "^3.7.8",
         "text-table": "^0.2.0",
         "try-resolve": "^1.0.1",
@@ -111,51 +148,90 @@
       }
     },
     "@textlint/markdown-to-ast": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-6.0.9.tgz",
-      "integrity": "sha512-hfAWBvTeUGh5t5kTn2U3uP3qOSM1BSrxzl1jF3nn0ywfZXpRBZr5yRjXnl4DzIYawCtZOshmRi/tI3/x4TE1jQ==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-6.1.7.tgz",
+      "integrity": "sha512-B0QtokeQR4a9+4q0NQr8T9l7A1fFihTN5Ze57tVgqW+3ymzXEouh8DvPHeNQ4T6jEkAThvdjk95mxAMpGRJ79w==",
       "dev": true,
       "requires": {
-        "@textlint/ast-node-types": "^4.0.3",
-        "debug": "^2.1.3",
+        "@textlint/ast-node-types": "^4.2.5",
+        "debug": "^4.1.1",
         "remark-frontmatter": "^1.2.0",
         "remark-parse": "^5.0.0",
         "structured-source": "^3.0.2",
         "traverse": "^0.6.6",
         "unified": "^6.1.6"
+      },
+      "dependencies": {
+        "@textlint/ast-node-types": {
+          "version": "4.2.5",
+          "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.2.5.tgz",
+          "integrity": "sha512-+rEx4jLOeZpUcdvll7jEg/7hNbwYvHWFy4IGW/tk2JdbyB3SJVyIP6arAwzTH/sp/pO9jftfyZnRj4//sLbLvQ==",
+          "dev": true
+        }
       }
     },
+    "@textlint/module-interop": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-1.0.2.tgz",
+      "integrity": "sha512-qQ6dqlg4SYywCywimIbkveQZu1MG6ugf6fcJuWDi3D51FbdkSRsMrPusJ1YoW6Y3XBp0ww9fJjXWtlUStGeQsw==",
+      "dev": true
+    },
     "@textlint/text-to-ast": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@textlint/text-to-ast/-/text-to-ast-3.0.9.tgz",
-      "integrity": "sha512-0Vycl2XtGv3pUtUNkBn9M/e3jBAtmlh7STUa3GuiyATXg49PsqqX7c8NxGPrNqMvDYCJ3ZubBx8GSEyra6ZWFw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@textlint/text-to-ast/-/text-to-ast-3.1.7.tgz",
+      "integrity": "sha512-CBAEQmiEa2G/wonlLr1HgUtXfTSas6OGGvYGRIRMJweNh5Ilhbz2nM2/9XQMfLQbdn5pGYrAAAQRB2+/9fZ31A==",
       "dev": true,
       "requires": {
-        "@textlint/ast-node-types": "^4.0.3"
+        "@textlint/ast-node-types": "^4.2.5"
+      },
+      "dependencies": {
+        "@textlint/ast-node-types": {
+          "version": "4.2.5",
+          "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.2.5.tgz",
+          "integrity": "sha512-+rEx4jLOeZpUcdvll7jEg/7hNbwYvHWFy4IGW/tk2JdbyB3SJVyIP6arAwzTH/sp/pO9jftfyZnRj4//sLbLvQ==",
+          "dev": true
+        }
       }
     },
     "@textlint/textlint-plugin-markdown": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-markdown/-/textlint-plugin-markdown-5.0.1.tgz",
-      "integrity": "sha512-5YnBu14lejHsNgY1jAbvDo7DT73NdQ3tMme49l0aG8bMpYq24kblE0bHHl+oQOAqDMav7vYU840Z7rkUrnlKIA==",
+      "version": "5.1.12",
+      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-markdown/-/textlint-plugin-markdown-5.1.12.tgz",
+      "integrity": "sha512-CJWWTaomR22hQD3ogrZujMH1pNN7DqZadmx9CJXxgKwpI/cuD5d2kClwXO3MeLFckJr5HRso7SFN5ebqKu1ycw==",
       "dev": true,
       "requires": {
-        "@textlint/markdown-to-ast": "^6.0.9"
+        "@textlint/markdown-to-ast": "^6.1.7"
       }
     },
     "@textlint/textlint-plugin-text": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-text/-/textlint-plugin-text-4.0.1.tgz",
-      "integrity": "sha512-7LIzZy/3Fczfxb0+PkpcvOTHRP5nWl6RDB4yglEcTF/WSih8poUU9Pkv/DPViFtF1NHLQC8L6k0eCf0JNE6I6w==",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-text/-/textlint-plugin-text-4.1.13.tgz",
+      "integrity": "sha512-KQfSYNDt8HSX8ZL/r86N8OrAuQ9LEuevAtGomtfkw0h7Ed/pUfmuYXjht8wYRdysYBa4JyjrXcmqzRAUdkWrag==",
       "dev": true,
       "requires": {
-        "@textlint/text-to-ast": "^3.0.9"
+        "@textlint/text-to-ast": "^3.1.7"
       }
     },
-    "@types/bluebird": {
-      "version": "3.5.24",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.24.tgz",
-      "integrity": "sha512-YeQoDpq4Lm8ppSBqAnAeF/xy1cYp/dMTif2JFcvmAbETMRlvKHT2iLcWu+WyYiJO3b3Ivokwo7EQca/xfLVJmg==",
+    "@textlint/types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-1.3.1.tgz",
+      "integrity": "sha512-9MJ6PRPYWiFs2lfvp/Qhq72WrkZLL5ncBUXAVoj1Ug17ug8d7psmr/KJstMMocW3EWHSOuIDj7unh413c3jPqQ==",
+      "dev": true,
+      "requires": {
+        "@textlint/ast-node-types": "^4.2.5"
+      },
+      "dependencies": {
+        "@textlint/ast-node-types": {
+          "version": "4.2.5",
+          "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.2.5.tgz",
+          "integrity": "sha512-+rEx4jLOeZpUcdvll7jEg/7hNbwYvHWFy4IGW/tk2JdbyB3SJVyIP6arAwzTH/sp/pO9jftfyZnRj4//sLbLvQ==",
+          "dev": true
+        }
+      }
+    },
+    "@textlint/utils": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@textlint/utils/-/utils-1.0.3.tgz",
+      "integrity": "sha512-6oGaBKXYpg5Ooph5p32OFdp1dXDUC1z5mpHg2gmQbx6QZjmP4QX+ygBQdNoCq15d1w88+We6koJl0n0WXjItYw==",
       "dev": true
     },
     "ajv": {
@@ -286,21 +362,15 @@
       }
     },
     "bail": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
-      "integrity": "sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
+      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
       "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
-    },
-    "bluebird": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
       "dev": true
     },
     "boundary": {
@@ -325,15 +395,9 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
-    },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -342,24 +406,35 @@
         "has-ansi": "^2.0.0",
         "strip-ansi": "^3.0.0",
         "supports-color": "^2.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
       }
     },
     "character-entities": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.2.tgz",
-      "integrity": "sha512-sMoHX6/nBiy3KKfC78dnEalnpn0Az0oSNvqUWYTtYrhRI5iUIYsROU48G+E+kMFQzqXaJ8kHJZ85n7y6/PHgwQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
       "dev": true
     },
     "character-entities-legacy": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz",
-      "integrity": "sha512-9NB2VbXtXYWdXzqrvAHykE/f0QJxzaKIpZ5QzNZrrgQ7Iyxr2vnfS8fCBNVW9nUEZE0lo57nxKRqnzY/dKrwlA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
       "dev": true
     },
     "character-reference-invalid": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz",
-      "integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
       "dev": true
     },
     "charenc": {
@@ -378,12 +453,6 @@
         "emoji-regex": "^6.4.1",
         "end-with": "^1.0.2"
       }
-    },
-    "circular-json": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-      "dev": true
     },
     "clone-regexp": {
       "version": "1.0.1",
@@ -414,9 +483,9 @@
       "dev": true
     },
     "collapse-white-space": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.4.tgz",
-      "integrity": "sha512-YfQ1tAUZm561vpYD+5eyWN8+UsceQbSrqqlc/6zDY2gtAE+uZLSdkkovhnGpmCThsvKBFakq4EdY/FF93E8XIw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
+      "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
       "dev": true
     },
     "commandpost": {
@@ -456,19 +525,35 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "dev": true,
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
     "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "dev": true,
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      },
+      "dependencies": {
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        }
+      }
     },
     "deep-is": {
       "version": "0.1.3",
@@ -486,9 +571,9 @@
       }
     },
     "diff": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
-      "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
     "doublearray": {
@@ -576,22 +661,21 @@
       "dev": true
     },
     "fault": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.2.tgz",
-      "integrity": "sha512-o2eo/X2syzzERAtN5LcGbiVQ0WwZSlN3qLtadwAz3X8Bu+XWD16dja/KMsjZLiQr+BLGPDnHGkc4yUJf1Xpkpw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
       "dev": true,
       "requires": {
-        "format": "^0.2.2"
+        "format": "^0.2.0"
       }
     },
     "file-entry-cache": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "^2.0.1"
       }
     },
     "find-up": {
@@ -604,21 +688,26 @@
       }
     },
     "flat-cache": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
-      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "graceful-fs": "^4.1.2",
-        "rimraf": "~2.6.2",
-        "write": "^0.2.1"
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
       }
     },
     "flatmap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/flatmap/-/flatmap-0.0.3.tgz",
       "integrity": "sha1-Hxik2TgVLUlZZfnJWNkjqy3WabQ=",
+      "dev": true
+    },
+    "flatted": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
     "format": {
@@ -646,9 +735,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -660,9 +749,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
     },
     "has": {
@@ -690,9 +779,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
     },
     "inflight": {
@@ -711,27 +800,27 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
-    "interop-require": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/interop-require/-/interop-require-1.0.0.tgz",
-      "integrity": "sha1-5TEDZ5lEyI1+YQW2Kp9EdceDlx4=",
-      "dev": true
-    },
     "is-alphabetical": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.2.tgz",
-      "integrity": "sha512-V0xN4BYezDHcBSKb1QHUFMlR4as/XEuCZBzMJUU4n7+Cbt33SmUnSol+pnXFvLxSHNq2CemUXNdaXV6Flg7+xg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
       "dev": true
     },
     "is-alphanumerical": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
-      "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
       "dev": true,
       "requires": {
         "is-alphabetical": "^1.0.0",
         "is-decimal": "^1.0.0"
       }
+    },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+      "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -744,15 +833,6 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
-    },
-    "is-builtin-module": {
-      "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "^1.0.0"
-      }
     },
     "is-callable": {
       "version": "1.1.4",
@@ -767,9 +847,9 @@
       "dev": true
     },
     "is-decimal": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.2.tgz",
-      "integrity": "sha512-TRzl7mOCchnhchN+f3ICUCzYvL9ul7R+TYOsZ8xia++knyZAJfv/uA1FvQXsAnYIl1T3B2X5E/J7Wb1QXiIBXg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
       "dev": true
     },
     "is-file": {
@@ -788,9 +868,9 @@
       }
     },
     "is-hexadecimal": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
-      "integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
       "dev": true
     },
     "is-plain-obj": {
@@ -836,15 +916,15 @@
       "dev": true
     },
     "is-whitespace-character": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz",
-      "integrity": "sha512-SzM+T5GKUCtLhlHFKt2SDAX2RFzfS6joT91F2/WSi9LxgFdsnhfPK/UIA+JhRR2xuyLdrCys2PiFDrtn1fU5hQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
+      "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==",
       "dev": true
     },
     "is-word-character": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.2.tgz",
-      "integrity": "sha512-T3FlsX8rCHAH8e7RE7PfOPZVFQlcV3XRF9eOOBQ1uf70OxO7CjjSOjeImMPCADBdYWcStAbVbYvJ1m2D3tb+EA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
+      "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==",
       "dev": true
     },
     "isarray": {
@@ -891,20 +971,12 @@
       }
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
+        "minimist": "^1.2.5"
       }
     },
     "jsonify": {
@@ -945,7 +1017,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -988,9 +1060,9 @@
       "dev": true
     },
     "markdown-escapes": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.2.tgz",
-      "integrity": "sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
+      "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
       "dev": true
     },
     "match-index": {
@@ -1023,18 +1095,18 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "moji": {
@@ -1070,19 +1142,19 @@
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
     "normalize-package-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
+        "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
       }
@@ -1098,6 +1170,81 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
+    },
+    "object-inspect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+      "dev": true
+    },
+    "object-is": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
+      "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
+        },
+        "is-callable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+          "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        }
+      }
     },
     "object-keys": {
       "version": "1.0.12",
@@ -1139,17 +1286,17 @@
       }
     },
     "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
+        "fast-levenshtein": "~2.0.6",
         "levn": "~0.3.0",
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "word-wrap": "~1.2.3"
       }
     },
     "p-limit": {
@@ -1177,9 +1324,9 @@
       "dev": true
     },
     "parse-entities": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.0.tgz",
-      "integrity": "sha512-XXtDdOPLSB0sHecbEapQi6/58U/ODj/KWfIXmmMCJF/eRn8laX6LZbOyioMoETOOJoWRW8/qTSl5VQkUIfKM5g==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
       "dev": true,
       "requires": {
         "character-entities": "^1.0.0",
@@ -1207,8 +1354,14 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-to-glob-pattern": {
@@ -1230,7 +1383,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
@@ -1287,35 +1440,15 @@
       "dev": true
     },
     "rc-config-loader": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-2.0.2.tgz",
-      "integrity": "sha512-Nx9SNM47eNRqe0TdntOY600qWb8NDh+xU9sv5WnTscEtzfTB0ukihlqwuCLPteyJksvZ0sEVPoySNE01TKrmTQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-3.0.0.tgz",
+      "integrity": "sha512-bwfUSB37TWkHfP+PPjb/x8BUjChFmmBK44JMfVnU7paisWqZl/o5k7ttCH+EQLnrbn2Aq8Fo1LAsyUiz+WF4CQ==",
       "dev": true,
       "requires": {
-        "debug": "^3.1.0",
+        "debug": "^4.1.1",
         "js-yaml": "^3.12.0",
-        "json5": "^1.0.1",
-        "object-assign": "^4.1.0",
-        "object-keys": "^1.0.12",
-        "path-exists": "^3.0.0",
+        "json5": "^2.1.1",
         "require-from-string": "^2.0.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true
-        }
       }
     },
     "read-pkg": {
@@ -1426,9 +1559,9 @@
       "dev": true
     },
     "remark-frontmatter": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-1.3.1.tgz",
-      "integrity": "sha512-Zj/fDMYnSVgMCeKp8fXIhtMoZq4G6E1dnwfMoO8fVXrm/+oVSiN8YMREtwN2cctgK9EsnYSeS1ExX2hcX/fE1A==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-1.3.3.tgz",
+      "integrity": "sha512-fM5eZPBvu2pVNoq3ZPW22q+5Ativ1oLozq2qYt9I2oNyxiUd/tDl0iLLntEVAegpZIslPWg1brhcP1VsaSVUag==",
       "dev": true,
       "requires": {
         "fault": "^1.0.1",
@@ -1476,13 +1609,22 @@
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
-    "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+    "resolve": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "path-parse": "^1.0.6"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
       }
     },
     "safe-buffer": {
@@ -1492,9 +1634,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true
     },
     "sentence-splitter": {
@@ -1509,7 +1651,7 @@
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
@@ -1532,9 +1674,9 @@
       }
     },
     "spdx-correct": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -1542,15 +1684,15 @@
       }
     },
     "spdx-exceptions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
       "dev": true
     },
     "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -1558,10 +1700,20 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
-      "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
+    },
+    "spellcheck-technical-word": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spellcheck-technical-word/-/spellcheck-technical-word-2.0.0.tgz",
+      "integrity": "sha1-ywN2uLvaYjm2vgCYeM+BzxcIBQM=",
+      "dev": true,
+      "requires": {
+        "structured-source": "^3.0.2",
+        "technical-word-rules": "^1.4.2"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -1570,9 +1722,9 @@
       "dev": true
     },
     "state-toggle": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.1.tgz",
-      "integrity": "sha512-Qe8QntFrrpWTnHwvwj2FZTgv+PKIsp0B9VxLzLLbSpPXWOgRgc5LVj/aTiSfK1RqIeF9jeC1UeOH8Q8y60A7og==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
+      "integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==",
       "dev": true
     },
     "string-width": {
@@ -1584,17 +1736,224 @@
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
         "strip-ansi": "^3.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
       }
     },
     "string.prototype.padstart": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.padstart/-/string.prototype.padstart-3.0.0.tgz",
-      "integrity": "sha1-W8+tOfRkm7LQMSkuGbzwtRDUskI=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.padstart/-/string.prototype.padstart-3.1.0.tgz",
+      "integrity": "sha512-envqZvUp2JItI+OeQ5UAh1ihbAV5G/2bixTojvlIa090GGqF+NQRxbWb2nv9fTGrZABv6+pE6jXoAZhhS2k4Hw==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.4.3",
-        "function-bind": "^1.0.2"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
+        },
+        "is-callable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+          "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        }
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
+        },
+        "is-callable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+          "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        }
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
+        },
+        "is-callable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+          "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        }
       }
     },
     "string_decoder": {
@@ -1607,12 +1966,20 @@
       }
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        }
       }
     },
     "strip-bom": {
@@ -1641,7 +2008,7 @@
     },
     "table": {
       "version": "3.8.3",
-      "resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
@@ -1686,6 +2053,12 @@
         }
       }
     },
+    "technical-word-rules": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/technical-word-rules/-/technical-word-rules-1.9.5.tgz",
+      "integrity": "sha512-2sqzeb3aE23GtIO9fL9sDbqdt4vnoks7nWZRUgqEvYkjEmmQjrnVfl3WTURBZFrpgAXBNk0AMhWCj+17mzYXhw==",
+      "dev": true
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -1693,41 +2066,48 @@
       "dev": true
     },
     "textlint": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/textlint/-/textlint-11.0.1.tgz",
-      "integrity": "sha512-PxIYevqDYactPIuVHOrMpEXB+2oraTV76yggLzq3QCkylKRp73qyPX9jdFsUxU4HkX80WRr+aumkvwzs3QRgdg==",
+      "version": "11.6.3",
+      "resolved": "https://registry.npmjs.org/textlint/-/textlint-11.6.3.tgz",
+      "integrity": "sha512-tTLLgB49zkJgq6GYDJOT6F31kHLulFjzovCHpN6ycv8d/aPcYl9vv7f/luR33YBQZdnGLtn+j8+G4GJAZ6Uz6w==",
       "dev": true,
       "requires": {
-        "@textlint/ast-node-types": "^4.0.3",
-        "@textlint/ast-traverse": "^2.0.9",
-        "@textlint/feature-flag": "^3.0.5",
-        "@textlint/fixer-formatter": "^3.0.8",
-        "@textlint/kernel": "^3.0.0",
-        "@textlint/linter-formatter": "^3.0.8",
-        "@textlint/textlint-plugin-markdown": "^5.0.1",
-        "@textlint/textlint-plugin-text": "^4.0.1",
-        "@types/bluebird": "^3.5.18",
-        "bluebird": "^3.0.5",
-        "debug": "^2.1.0",
-        "deep-equal": "^1.0.1",
-        "file-entry-cache": "^2.0.0",
+        "@textlint/ast-node-types": "^4.2.5",
+        "@textlint/ast-traverse": "^2.1.7",
+        "@textlint/feature-flag": "^3.1.6",
+        "@textlint/fixer-formatter": "^3.1.13",
+        "@textlint/kernel": "^3.2.1",
+        "@textlint/linter-formatter": "^3.1.12",
+        "@textlint/module-interop": "^1.0.2",
+        "@textlint/textlint-plugin-markdown": "^5.1.12",
+        "@textlint/textlint-plugin-text": "^4.1.13",
+        "@textlint/types": "^1.3.1",
+        "@textlint/utils": "^1.0.3",
+        "debug": "^4.1.1",
+        "deep-equal": "^1.1.0",
+        "file-entry-cache": "^5.0.1",
         "get-stdin": "^5.0.1",
-        "glob": "^7.1.1",
-        "interop-require": "^1.0.0",
+        "glob": "^7.1.3",
         "is-file": "^1.0.0",
         "log-symbols": "^1.0.2",
         "map-like": "^2.0.0",
         "md5": "^2.2.1",
         "mkdirp": "^0.5.0",
-        "object-assign": "^4.0.1",
         "optionator": "^0.8.0",
         "path-to-glob-pattern": "^1.0.2",
-        "rc-config-loader": "^2.0.1",
+        "rc-config-loader": "^3.0.0",
         "read-pkg": "^1.1.0",
         "read-pkg-up": "^3.0.0",
         "structured-source": "^3.0.2",
         "try-resolve": "^1.0.1",
         "unique-concat": "^0.2.2"
+      },
+      "dependencies": {
+        "@textlint/ast-node-types": {
+          "version": "4.2.5",
+          "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.2.5.tgz",
+          "integrity": "sha512-+rEx4jLOeZpUcdvll7jEg/7hNbwYvHWFy4IGW/tk2JdbyB3SJVyIP6arAwzTH/sp/pO9jftfyZnRj4//sLbLvQ==",
+          "dev": true
+        }
       }
     },
     "textlint-rule-helper": {
@@ -2156,6 +2536,27 @@
         }
       }
     },
+    "textlint-rule-spellcheck-tech-word": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-spellcheck-tech-word/-/textlint-rule-spellcheck-tech-word-5.0.0.tgz",
+      "integrity": "sha1-J5vjH9SzleH4e0oe9jkvFQSJTEI=",
+      "dev": true,
+      "requires": {
+        "spellcheck-technical-word": "^2.0.0",
+        "textlint-rule-helper": "^1.1.2"
+      },
+      "dependencies": {
+        "textlint-rule-helper": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
+          "integrity": "sha1-vmjUelFGsW3RFieMmut701YxzNo=",
+          "dev": true,
+          "requires": {
+            "unist-util-visit": "^1.1.0"
+          }
+        }
+      }
+    },
     "textlint-util-to-string": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/textlint-util-to-string/-/textlint-util-to-string-1.2.1.tgz",
@@ -2179,15 +2580,15 @@
       "dev": true
     },
     "trim-trailing-lines": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz",
-      "integrity": "sha512-bWLv9BbWbbd7mlqqs2oQYnLD/U/ZqeJeJwbO0FG2zA1aTq+HTvxfHNKFa/HGCVyJpDiioUYaBhfiT6rgk+l4mg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz",
+      "integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA==",
       "dev": true
     },
     "trough": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.3.tgz",
-      "integrity": "sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
+      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
       "dev": true
     },
     "try-resolve": {
@@ -2212,13 +2613,13 @@
       "dev": true
     },
     "unherit": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
-      "integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
+      "integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "xtend": "^4.0.1"
+        "inherits": "^2.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "unified": {
@@ -2266,9 +2667,9 @@
       "dev": true
     },
     "unist-util-remove-position": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz",
-      "integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
+      "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
       "dev": true,
       "requires": {
         "unist-util-visit": "^1.1.0"
@@ -2339,24 +2740,24 @@
       }
     },
     "vfile-location": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.4.tgz",
-      "integrity": "sha512-KRL5uXQPoUKu+NGvQVL4XLORw45W62v4U4gxJ3vRlDfI9QsT4ZN1PNXn/zQpKUulqGDpYuT0XDfp5q9O87/y/w==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
+      "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==",
       "dev": true
     },
     "vfile-message": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.0.2.tgz",
-      "integrity": "sha512-dNdEXHfPCvzyOlEaaQ+DcXpcxEz+pFvdrebKLiAMjobjaBC2bMeWoHOKPwJ+I8A4jQOEUDH7uoVcLWDLF1qhVQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+      "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
       "dev": true,
       "requires": {
         "unist-util-stringify-position": "^1.1.1"
       }
     },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
     "wrappy": {
@@ -2366,9 +2767,9 @@
       "dev": true
     },
     "write": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
@@ -2387,9 +2788,9 @@
       "dev": true
     },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
     "zlibjs": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,8 @@
 {
-  "name": "curriculum-textlint",
-  "scripts": {
-    "postinstall": "npm run update:submodule",
-    "postupdate": "npm run update:submodule",
-    "update:submodule": "git submodule update --init",
-    "start": "npm run check",
-    "check": "textlint ../curriculum/*/*.md",
-    "check:fix": "textlint --fix ../curriculum/*/*.md"
-  },
+  "name": "textlint-rule-preset-techpit-curriculum",
+  "description": "Techpit における教材の textlint ルールセット",
+  "version": "1.0.0",
+  "main": "techpit-curriculum.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Techpit-Market/curriculum-textlint.git"
@@ -15,6 +10,9 @@
   "bugs": {
     "url": "https://github.com/Techpit-Market/curriculum-textlint/issues"
   },
+  "keywords": [
+    "textlintrule"
+  ],
   "homepage": "https://github.com/Techpit-Market/curriculum-textlint#readme",
   "devDependencies": {
     "textlint": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "textlint-rule-preset-techpit-curriculum",
   "description": "Techpit における教材の textlint ルールセット",
   "version": "1.0.0",
-  "main": "techpit-curriculum.js",
+  "main": "preset-techpit-curriculum.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Techpit-Market/curriculum-textlint.git"
@@ -15,6 +15,7 @@
   ],
   "homepage": "https://github.com/Techpit-Market/curriculum-textlint#readme",
   "devDependencies": {
+    "@textlint/module-interop": "^1.0.2",
     "textlint": "^11.6.3",
     "textlint-rule-preset-ja-technical-writing": "^4.0.0",
     "textlint-rule-prh": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "homepage": "https://github.com/Techpit-Market/curriculum-textlint#readme",
   "devDependencies": {
     "textlint": "^11.6.3",
-    "textlint-rule-preset-ja-technical-writing": "^3.1.0",
-    "textlint-rule-prh": "^5.2.0",
+    "textlint-rule-preset-ja-technical-writing": "^4.0.0",
+    "textlint-rule-prh": "^5.3.0",
     "textlint-rule-spellcheck-tech-word": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,9 +14,8 @@
     "textlintrule"
   ],
   "homepage": "https://github.com/Techpit-Market/curriculum-textlint#readme",
-  "devDependencies": {
+  "dependencies": {
     "@textlint/module-interop": "^1.0.2",
-    "textlint": "^11.6.3",
     "textlint-rule-preset-ja-technical-writing": "^4.0.0",
     "textlint-rule-prh": "^5.3.0",
     "textlint-rule-spellcheck-tech-word": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
   ],
   "homepage": "https://github.com/Techpit-Market/curriculum-textlint#readme",
   "devDependencies": {
-    "textlint": "^11.0.1",
+    "textlint": "^11.6.3",
     "textlint-rule-preset-ja-technical-writing": "^3.1.0",
-    "textlint-rule-prh": "^5.2.0"
+    "textlint-rule-prh": "^5.2.0",
+    "textlint-rule-spellcheck-tech-word": "^5.0.0"
   }
 }

--- a/preset-techpit-curriculum.js
+++ b/preset-techpit-curriculum.js
@@ -1,0 +1,16 @@
+const { moduleInterop } = require('@textlint/module-interop');
+
+module.exports = {
+  rules: {
+    'preset-ja-technical-writing': moduleInterop(require('textlint-rule-preset-ja-technical-writing')),
+    'prh': moduleInterop(require('textlint-rule-prh')),
+    'spellcheck-tech-word': moduleInterop(require('textlint-rule-spellcheck-tech-word')),
+  },
+  rulesConfig: {
+    'preset-ja-technical-writing': true,
+    'prh': {
+      rulePaths: ['./prh-rules.yml']
+    },
+    'spellcheck-tech-word': true,
+  },
+};

--- a/preset-techpit-curriculum.js
+++ b/preset-techpit-curriculum.js
@@ -1,15 +1,19 @@
+const path = require('path');
+
 const { moduleInterop } = require('@textlint/module-interop');
+
+const presetJTW = moduleInterop(require('textlint-rule-preset-ja-technical-writing'));
 
 module.exports = {
   rules: {
-    'preset-ja-technical-writing': moduleInterop(require('textlint-rule-preset-ja-technical-writing')),
+    ...presetJTW.rules,
     'prh': moduleInterop(require('textlint-rule-prh')),
     'spellcheck-tech-word': moduleInterop(require('textlint-rule-spellcheck-tech-word')),
   },
   rulesConfig: {
-    'preset-ja-technical-writing': true,
+    ...presetJTW.rulesConfig,
     'prh': {
-      rulePaths: ['./prh-rules.yml']
+      rulePaths: [path.join(__dirname, 'prh-rules.yml')]
     },
     'spellcheck-tech-word': true,
   },

--- a/prh-rules.yml
+++ b/prh-rules.yml
@@ -1,5 +1,5 @@
+# prh version
 version: 1
-
 rules:
   # Google Chromeの表記の統一
   - pattern:

--- a/techpit-curriculum.js
+++ b/techpit-curriculum.js
@@ -1,0 +1,8 @@
+module.exports = {
+  rules: {
+    'preset-ja-technical-writing': true,
+    'prh': {
+      rulePaths: ['./prh-rules.yml']
+    },
+  },
+};

--- a/techpit-curriculum.js
+++ b/techpit-curriculum.js
@@ -1,9 +1,0 @@
-module.exports = {
-  rules: {
-    'preset-ja-technical-writing': true,
-    'prh': {
-      rulePaths: ['./prh-rules.yml']
-    },
-    'spellcheck-tech-word': true,
-  },
-};

--- a/techpit-curriculum.js
+++ b/techpit-curriculum.js
@@ -4,5 +4,6 @@ module.exports = {
     'prh': {
       rulePaths: ['./prh-rules.yml']
     },
+    'spellcheck-tech-word': true,
   },
 };


### PR DESCRIPTION
techpit として利用したいプリセットを submodule 形式ではなく npm 形式として提供できないかと思い修正。

textlint による preset をベースに拡張する機能は[サポートされておらず、まだ提案段階](https://github.com/textlint/textlint/issues/210)。
ただ、[textlint-rule-preset-ja-technical-writing](https://github.com/textlint-ja/textlint-rule-preset-ja-technical-writing)において、[他のpresetのルールを取り込むコードがあった](https://github.com/textlint-ja/textlint-rule-preset-ja-technical-writing/blob/45c01f0b2ab920cf31da9f2386a3d0ce51e363d9/lib/textlint-rule-preset-ja-technical-writing.js#L3-L12)ので、それを参考に他の preset のすべてのルールを取り込むコードを書いて既存 preset の拡張を実現した。

この方法で問題がないかの検証はそこまで行っていないが、prh がマージされて両方のlintが適用されていることは確認できた。