### PR TITLE
句点ルールを除外

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -6,6 +6,7 @@
         "allowFullWidthExclamation": true,  // 全角の「！」を使えるようにする
         "allowFullWidthQuestion": true,     // 全角の「？」を使えるようにする
       },
+      // TODO: 句点+空白はOKになるように修正 or 空白での改行を禁止ルールするルールを策定したら除外を戻す
       "ja-no-mixed-period": false, //句点ルールを除外
     },
     "preset-techpit-host-guide": true,

--- a/.textlintrc
+++ b/.textlintrc
@@ -5,7 +5,8 @@
       "no-exclamation-question-mark": {     // 感嘆符
         "allowFullWidthExclamation": true,  // 全角の「！」を使えるようにする
         "allowFullWidthQuestion": true,     // 全角の「？」を使えるようにする
-      }
+      },
+      "ja-no-mixed-period": false, //句点ルールを除外
     },
     "preset-techpit-host-guide": true,
     "prh": {


### PR DESCRIPTION
## 概要
OKRに記載の「句点の誤検知が多すぎるので削除する」のPRです

markdownの改行に使うスペースが誤検知の原因となっており、「句点+空白はOK、それ以外は検知」になるように改善を考えましたが
https://github.com/textlint-ja/textlint-rule-ja-no-mixed-period
https://github.com/azu/check-ends-with-period
にある程度手をいれる必要があるため、取り急ぎ無効化しています。

## 実際の誤検知例
![____________________________2022-03-18_21.07.41.png](https://user-images.githubusercontent.com/45286006/159029660-13618cca-afc8-42a2-9e6e-4ddd91c0b27c.png)