### PR TITLE
章ごとにtextlintをかけるオプションを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ npm install
 npm run check
 ```
 
+`check:chap --chapter=<章番号>`で任意の章のみに対して実行できます。
+```console
+npm run check:chap --chapter=1
+```
+
 ### 機械的に修正可能な箇所の自動修正
 
 機械的に修正可能な箇所は、次のコマンドを実行することで自動的に修正されます。

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "npm run check",
     "check": "textlint ../curriculum/*/*.md",
     "check:fix": "textlint --fix ../curriculum/*/*.md",
-    "check:chap": "textlint ../curriculum/${npm_config_chap}*/*.md",
+    "check:chap": "textlint ../curriculum/${npm_config_chapter}[!0-9]*/*.md",
     "gen-report": "node ./gen-report/index.js",
     "test": "echo 'Error: no test specified'"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "npm run check",
     "check": "textlint ../curriculum/*/*.md",
     "check:fix": "textlint --fix ../curriculum/*/*.md",
+    "check:chap": "textlint ../curriculum/${npm_config_chap}*/*.md",
     "gen-report": "node ./gen-report/index.js",
     "test": "echo 'Error: no test specified'"
   },


### PR DESCRIPTION
## 概要
`npm run check:chap  --chap=<章番号>`で章ごとに区切られたディレクトリ配下の教材のみtextlintを実行できるオプションを作成しました。
`章番号-章タイトル`でディレクトリを作る方が多かったので、前方部分一致で指定できるようにしています。

## 実行例
```
TakumanoMacBook-Pro:takuma@:~/techpit-work/text/aws-chatserver/curriculum-textlint
[09:33:22] $ npm run check:chap --chap=3

> curriculum-textlint@ check:chap /Users/takuma/techpit-work/text/aws-chatserver/curriculum-textlint
> textlint ../curriculum/${npm_config_chap}*/*.md


/Users/takuma/techpit-work/text/aws-chatserver/curriculum/3章：アカウントのクリーンアップ/3-1：この章でやること.md
  7:52  error  一つの文で"、"を3つ以上使用しています  preset-ja-technical-writing/max-ten

✖ 1 problem (1 error, 0 warnings)

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! curriculum-textlint@ check:chap: `textlint ../curriculum/${npm_config_chap}*/*.md`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the curriculum-textlint@ check:chap script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/takuma/.npm/_logs/2022-07-14T00_33_36_776Z-debug.log
```
