### PR TITLE
CIの修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ language: node_js
 
 node_js: "stable"
 
+dist: focal
+
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
## やったこと
CIがコケる問題の修正を行いました

## 原因詳細と対処法
エラーログはこれ (from https://app.travis-ci.com/github/Techpit-Market/curriculum-textlint/jobs/579140833 )
```
node: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.27' not found (required by node)
node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.25' not found (required by node)
node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by node)

The command "npm config set spin false" failed and exited with 1 during .
```

同様の現象が[Community](https://travis-ci.community/t/the-command-npm-config-set-spin-false-failed-and-exited-with-1-during/12909/4)に上がっており、原因は「Node18系にあがった際に glibc >2.17が必要になったが、glibc >2.17はUbuntu18.10以降でないと入っていない」ことらしい。
- https://github.com/nodejs/node/issues/42351

`dist: focal`を指定するとビルドに使用するOSをUbuntu20.04に変更できるので、これで回避。
（ちなみに変更前はUbuntu16.04でビルドしようとしていたらしい…）
